### PR TITLE
dont start service, as default output config is no longer present

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'camden@northpage.com'
 license 'Apache-2.0'
 description 'Installs/Configures telegraf'
 long_description 'Installs/Configures telegraf'
-version '0.12.1002'
+version '0.13.0'
 source_url 'https://github.com/NorthPage/telegraf-cookbook'
 issues_url 'https://github.com/NorthPage/telegraf-cookbook/issues'
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -187,7 +187,6 @@ action :create do
   service "telegraf_#{new_resource.name}" do
     service_name 'telegraf'
     action :enable
-    delayed_action :start
   end
 end
 


### PR DESCRIPTION
Since this MR https://github.com/influxdata/telegraf/pull/12158 Telegraf doesn't include a working default config anymore.  So it can't start the service before a valid config is put in place. This fixes that by just not starting the service on creation.