### PR TITLE
fix: input.io is removed in Telegraf 1.30, diskio has been available since 1.10

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -65,7 +65,7 @@ default['telegraf']['inputs'] = {
     'drop' => ['cpu_time'],
   },
   'disk' => {},
-  'io' => {},
+  'diskio' => {},
   'mem' => {},
   'net' => {},
   'swap' => {},

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'camden@northpage.com'
 license 'Apache-2.0'
 description 'Installs/Configures telegraf'
 long_description 'Installs/Configures telegraf'
-version '0.13.1000'
+version '0.13.1001'
 source_url 'https://github.com/NorthPage/telegraf-cookbook'
 issues_url 'https://github.com/NorthPage/telegraf-cookbook/issues'
 


### PR DESCRIPTION
https://www.influxdata.com/blog/telegraf-1-30-release-notes/