### PR TITLE
Introduce telegraf 1.36 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ as needed.  Alternatively, you can use the custom resources directly.
 | node['telegraf']['config']           | Hash   | Config variables to be written to the telegraf config | {'tags' => {},'agent' => {'interval' => '10s','round_interval' => true,'flush_interval' => '10s','flush_jitter' => '5s'}                                            |
 | node['telegraf']['outputs']          | Hash  | telegraf outputs                                      | {'influxdb' => {'urls' => ['http://localhost:8086'],'database' => 'telegraf','precision' => 's'}}                                                                   |
 | node['telegraf']['include_repository'] | [TrueClass, FalseClass] | Whether or not to pull in the InfluxDB repository to install from. | true |
-| node['telegraf']['inputs']           | Hash   | telegraf inputs                                       | {'cpu' => {'percpu' => true,'totalcpu' => true,'drop' => ['cpu_time'],},'disk' => {},'io' => {},'mem' => {},'net' => {},'swap' => {},'system' => {}}                |
+| node['telegraf']['inputs']           | Hash   | telegraf inputs                                       | {'cpu' => {'percpu' => true,'totalcpu' => true,'drop' => ['cpu_time'],},'disk' => {},'diskio' => {},'mem' => {},'net' => {},'swap' => {},'system' => {}}                |
 | node['telegraf']['perf_counters']           | Hash   | telegraf performance counters | {{  'Processor' => { 'Instances' => ['*'] 'Counters' => ['% Idle Time','% Interrupt Time','% Privileged Time','% User Time','% Processor Time','% DPC Time',],'Measurement' => 'win_cpu','IncludeTotal' => true}} |
 
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -62,7 +62,7 @@ default['telegraf']['inputs'] = {
   'cpu' => {
     'percpu' => true,
     'totalcpu' => true,
-    'drop' => ['cpu_time'],
+    'fieldexclude' => ['cpu_time'],
   },
   'disk' => {},
   'diskio' => {},

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -67,7 +67,9 @@ default['telegraf']['inputs'] = {
   'disk' => {},
   'diskio' => {},
   'mem' => {},
-  'net' => {},
+  'net' => {
+    'ignore_protocol_stats' => true,
+  },
   'swap' => {},
   'system' => {},
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'camden@northpage.com'
 license 'Apache-2.0'
 description 'Installs/Configures telegraf'
 long_description 'Installs/Configures telegraf'
-version '0.13.1002'
+version '0.13.1003'
 source_url 'https://github.com/NorthPage/telegraf-cookbook'
 issues_url 'https://github.com/NorthPage/telegraf-cookbook/issues'
 


### PR DESCRIPTION
The following changes remove the issues of deprecation errors when using telegraf 1.36.0 (or later).

- drop to fieldexclude for inputs.cpu
- add ignore_protocol_stats = true for inputs.net as it is no longer part of this input

Updated the README.md to reflect the previous change of io -> diskio